### PR TITLE
Add option to hide footer

### DIFF
--- a/src/PdfTableOfContent.php
+++ b/src/PdfTableOfContent.php
@@ -58,9 +58,10 @@ class PdfTableOfContent
     /**
      * Generates a merged PDF file from the already stored pdf files
      * @param string $outputFilename the file to write to
+     * @param bool $showFooter show pageNo and total no of pages
      * @return array return table of content
      */
-    public function merge(string $outputFilename): array
+    public function merge(string $outputFilename, bool $showFooter = true): array
     {
         if (count($this->documents) === 0) {
             throw new NoFilesDefinedException();
@@ -82,6 +83,7 @@ class PdfTableOfContent
             for ($i = 1; $i <= $pageCount; $i++) {
 
                 $pdf->SetPrintHeader(false);
+                $pdf->setPrintFooter($showFooter);
                 $pageId = $pdf->ImportPage($i);
                 $size = $pdf->getTemplateSize($pageId);
                 $pdf->AddPage('P', $size);


### PR DESCRIPTION
I'm using this class to create a front page with TOC to include as the first page in the merged document.

To do that, I first need to merge my documents to get the TOC object.  Then I'm using the TOC object and another plugin to generate the front page.  After that, I'm merging once more. 

But I can't have the footer generated both times, because it'll overlap. So I'm proposing a small change to allow the user to choose whether the footer should be generated.